### PR TITLE
[기능 추가] 계정명, 비밀번호 로그인 API 구현

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -133,7 +133,7 @@ REST_FRAMEWORK = {
 REST_USE_JWT = True
 
 SIMPLE_JWT = {
-    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=5),
+    "ACCESS_TOKEN_LIFETIME": timedelta(hours=2),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
     "UPDATE_LAST_LOGIN": True,
 }

--- a/swagger_parameters.py
+++ b/swagger_parameters.py
@@ -1,0 +1,20 @@
+from drf_yasg import openapi
+
+USER_REGISTER_PARAMETERS = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'username': openapi.Schema(type=openapi.TYPE_STRING, description='계정명'),
+        'email': openapi.Schema(type=openapi.TYPE_STRING, description='이메일'),
+        'password': openapi.Schema(type=openapi.TYPE_STRING, description='비밀번호'),
+    },
+    required=['username', 'email' ,'password']
+)
+
+USER_LOGIN_PARAMETERS = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        'username': openapi.Schema(type=openapi.TYPE_STRING, description='계정명'),
+        'password': openapi.Schema(type=openapi.TYPE_STRING, description='비밀번호')
+    },
+    required=['username', 'password']
+)

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -3,6 +3,15 @@ from rest_framework import serializers
 from users.models import User
 
 
+class UserSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = User
+        fields = [
+            'username'
+        ]
+
+
 class SignupSerializer(serializers.ModelSerializer):
 
     class Meta:

--- a/users/tests/test_login.py
+++ b/users/tests/test_login.py
@@ -1,0 +1,19 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from users.models import User
+
+
+class LoginAPIViewTestCase(APITestCase):
+
+    def setUp(self):
+        self.data = {"username" : "testuser2", "password" : "testuser2"}
+        self.user = User.objects.create_user(username='testuser2',email='testuser2@test.com', password='testuser2')
+
+    def test_login(self):
+        url = reverse("user-login")
+
+        response = self.client.post(url, self.data)
+        self.assertEqual(response.status_code, 200)
+

--- a/users/tests/test_signup.py
+++ b/users/tests/test_signup.py
@@ -1,3 +1,18 @@
-from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
 
-# Create your tests here.
+
+class SignupAPIViewTestCase(APITestCase):
+
+    def test_signup(self):
+        url = reverse("user-signup")
+        user_data = {
+            "username" : "testuser2",
+            "email" : "testuser2@test.com",
+            "password" : "testuser2"
+        }
+
+        response = self.client.post(url, user_data)
+        self.assertEqual(response.status_code, 201)
+

--- a/users/urls.py
+++ b/users/urls.py
@@ -4,6 +4,6 @@ from users.views import LoginView, SignupAPIView
 
 urlpatterns = [
     path('signup/', SignupAPIView.as_view(), name='user-signup'),
-    path('login/', LoginView.as_view(), name='user_login'),
-    # path('logout/', LogoutView.as_view(), name='user_logout')
+    path('login/', LoginView.as_view(), name='user-login'),
+    # path('logout/', LogoutView.as_view(), name='user-logout')
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -2,8 +2,14 @@ from django.urls import path
 
 from users.views import LoginView, SignupAPIView
 
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenBlacklistView
+
 urlpatterns = [
     path('signup/', SignupAPIView.as_view(), name='user-signup'),
     path('login/', LoginView.as_view(), name='user-login'),
     # path('logout/', LogoutView.as_view(), name='user-logout')
+
+    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('token/blacklist/', TokenBlacklistView.as_view(), name='token_blacklist'),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
 
-from users.views import SignupAPIView
+from users.views import LoginView, SignupAPIView
 
 urlpatterns = [
     path('signup/', SignupAPIView.as_view(), name='user-signup'),
+    path('login/', LoginView.as_view(), name='user_login'),
+    # path('logout/', LogoutView.as_view(), name='user_logout')
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -2,17 +2,22 @@ from rest_framework.views import APIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from drf_yasg.utils import swagger_auto_schema
 
-from users.serializers import SignupSerializer
+from django.contrib.auth import authenticate
 
+from users.serializers import SignupSerializer, UserSerializer
+from swagger_parameters import *
 
 # api/v1/users/signup/
 class SignupAPIView(APIView):
     permission_classes = [AllowAny]
 
     @swagger_auto_schema(
-        request_body=SignupSerializer,
+        operation_id="회원가입",
+        operation_description="계정명, 이메일, 비밀번호를 입력받아 회원가입을 진행합니다.",
+        request_body=USER_REGISTER_PARAMETERS
     )
     def post(self, request):
         serializer = SignupSerializer(data=request.data)
@@ -29,3 +34,47 @@ class SignupAPIView(APIView):
             return Response(data, status=status.HTTP_201_CREATED)
         
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+
+# api/v1/users/login/
+class LoginView(APIView):
+    permission_classes = [AllowAny]
+
+    @swagger_auto_schema(
+        operation_id="로그인",
+        operation_description="계정명, 비밀번호로 로그인합니다.",
+        request_body=USER_LOGIN_PARAMETERS
+    )
+    def post(self, request):
+        username = request.data.get("username")
+        password = request.data.get("password")
+
+        if username is None:
+            return Response({"message":"계정명은 필수 입력사항입니다."}, status=status.HTTP_400_BAD_REQUEST)
+        
+        if password is None:
+            return Response({"message":"비밀번호는 필수 입력사항입니다."}, status=status.HTTP_400_BAD_REQUEST)
+        
+        # 해당하는 사용자가 있는지 판단
+        user = authenticate(username=username, password=password)
+        if user is None:
+            return Response({"message": "사용자를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+        
+        serializer = UserSerializer(user)
+
+        # 토큰 발급
+        token = TokenObtainPairSerializer.get_token(user)
+        refresh_token = str(token)
+        access_token = str(token.access_token)
+
+        res = Response(
+            {
+                "data": serializer.data,
+                "message": "login success"
+            },
+            status=status.HTTP_200_OK,
+        )
+
+        res.set_cookie("access", access_token, httponly=True)
+        
+        return res


### PR DESCRIPTION
## 반영 브랜치
feature/#2 -> develop

## 변경 사항
- 기본 로그인 API 구현
 - 로그인 시 Refresh/Access Token 발급
 - access token의 경우 쿠키에 저장됨 

## 테스트 결과
![image](https://github.com/kyeon06/django-sample-project/assets/111492415/47553937-b640-4107-b869-8e229e4d56c3)

